### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-publish:
     name: Build and publish
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/dezh-tech/rokovo-cli/security/code-scanning/2](https://github.com/dezh-tech/rokovo-cli/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow or to the specific job. The minimal starting point is `contents: read`, which allows the workflow to read repository contents but not write to them. Since the workflow is publishing to PyPI and not performing any actions that require write access to the repository, this is sufficient. The best place to add this is at the job level (under `build-and-publish:`), unless you want to set it for all jobs in the workflow. You should insert the following block directly under the job name (line 10):

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
