### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/dezh-tech/rokovo-cli/security/code-scanning/1](https://github.com/dezh-tech/rokovo-cli/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow or to the specific job(s) that limits the permissions of the GITHUB_TOKEN to only what is necessary. In this case, the workflow only needs to read repository contents (for checkout and possibly for build/linting), so the minimal permissions block should be `contents: read`. This can be added either at the root of the workflow (to apply to all jobs) or at the job level (to apply only to the specific job). The best practice is to add it at the root unless different jobs require different permissions. You should edit `.github/workflows/ci.yml` and insert the following block after the `name: CI` line (before `on:`):

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
